### PR TITLE
fix deceleration equation

### DIFF
--- a/graceful_controller/src/graceful_controller.cpp
+++ b/graceful_controller/src/graceful_controller.cpp
@@ -66,7 +66,7 @@ bool GracefulController::approach(const double x, const double y, const double t
   // Compute max_velocity based on curvature
   double v = max_velocity_ / (1 + beta_ * std::pow(fabs(k), lambda_));
   // Limit velocity based on approaching target
-  double approach_limit = std::sqrt(2 * max_accel_ * r);
+  double approach_limit = 2 * max_accel_ * r;
   v = std::min(v, approach_limit);
   v = std::min(std::max(v, min_velocity_), max_velocity_);
 

--- a/graceful_controller_ros/src/graceful_controller_ros.cpp
+++ b/graceful_controller_ros/src/graceful_controller_ros.cpp
@@ -492,7 +492,7 @@ public:
     }
 
     cmd_vel.linear.x = 0.0;
-    cmd_vel.angular.z = sqrt(2 * limits.acc_lim_theta * fabs(yaw));
+    cmd_vel.angular.z = 2 * limits.acc_lim_theta * fabs(yaw);
     cmd_vel.angular.z = sign(yaw) * std::min(max_vel_th, std::max(min_in_place_vel_theta_, cmd_vel.angular.z));
 
     // Return error


### PR DESCRIPTION
this was straight of of the base_local_planner, equation is
wrong for physics but was probably hacked by someone to work
on PR2. confirmed that removing it avoids robot running into
things or getting stuck in costmap obstacle inflation