### PR TITLE
add min_lookahead parameter

### DIFF
--- a/graceful_controller_ros/cfg/GracefulController.cfg
+++ b/graceful_controller_ros/cfg/GracefulController.cfg
@@ -24,7 +24,8 @@ gen.add("beta", double_t, 0, "Parameters for selecting velocity from curvature",
 gen.add("lambda", double_t, 0, "Parameters for selecting velocity from curvature", 2.0, 0, 10)
 
 # Parameters for path following
-gen.add("max_lookahead", double_t, 0, "Maximum distance to look ahead", 1.0, 0)
+gen.add("min_lookahead", double_t, 0, "Minimum distance to target goal", 0.05, 0)
+gen.add("max_lookahead", double_t, 0, "Maximum distance to target goal", 1.0, 0)
 gen.add("initial_rotate_tolerance", double_t, 0, "Tolerance for initial rotation to complete (0.0 to disable)", 0.1, 0)
 
 exit(gen.generate("graceful_controller", "graceful_controller", "GracefulController"))


### PR DESCRIPTION
when the pose is very close to the robot, we can get
some instability (rapid side-to-side movement due to
large angular errors over small linear distances). by
adding this parameter, we can instead fallback to
recovery behaviors and find a better path.