### PR TITLE
fix bug in latch_xy_goal_tolerance

### DIFF
--- a/graceful_controller_ros/src/graceful_controller_ros.cpp
+++ b/graceful_controller_ros/src/graceful_controller_ros.cpp
@@ -536,7 +536,9 @@ public:
     double angle = angles::shortest_angular_distance(tf2::getYaw(goal.pose.orientation),
                                                      tf2::getYaw(robot_pose_.pose.orientation));
 
-    return (dist < xy_goal_tolerance_) && (fabs(angle) < yaw_goal_tolerance_);
+    double dist_reached = goal_tolerance_met_ || (dist < xy_goal_tolerance_);
+
+    return dist_reached && (fabs(angle) < yaw_goal_tolerance_);
   }
 
   /**


### PR DESCRIPTION
While the main control loop can latch the goal (thus it will stop trying to hunt around) - that isn't understood by the isGoalReached() function - which leads to the robot wiggling back and forth for a while