### PR TITLE
add velocity limit to goal tolerance

### DIFF
--- a/graceful_controller_ros/cfg/GracefulController.cfg
+++ b/graceful_controller_ros/cfg/GracefulController.cfg
@@ -17,6 +17,11 @@ gen.add("acc_lim_theta", double_t, 0, "The acceleration limit of the robot in th
 gen.add("xy_goal_tolerance", double_t, 0, "Within what maximum distance we consider the robot to be in goal", 0.1)
 gen.add("yaw_goal_tolerance", double_t, 0, "Within what maximum angle difference we consider the robot to face goal direction", 0.1)
 
+# Parameters to make sure we get close to stopped before declaring goal reached
+# NOTE: these only work when the odom_topic is set
+gen.add("xy_vel_goal_tolerance", double_t, 0, "Maximum speed that robot can be moving at when latching goal", 1.0)
+gen.add("yaw_vel_goal_tolerance", double_t, 0, "Maximum speed that robot can be rotating at when latching goal", 1.0)
+
 # Parameters for control law
 gen.add("k1", double_t, 0, "Ratio of rate of change of theta to rate of change of R", 2.0, 0, 10)
 gen.add("k2", double_t, 0, "How quickly we converge to the slow manifold", 1.0, 0, 10)

--- a/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
+++ b/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
@@ -145,6 +145,8 @@ private:
   double scaling_step_;
   double xy_goal_tolerance_;
   double yaw_goal_tolerance_;
+  double xy_vel_goal_tolerance_;
+  double yaw_vel_goal_tolerance_;
   double min_lookahead_;
   double max_lookahead_;
   double resolution_;


### PR DESCRIPTION
the graceful control law automatically slows the robot as the goal
is approached, however when goal tolerances are large and
reachable, the robot will instantly shift from high speed linear
motion to final in place rotation - and this is NOT graceful.