### PR TITLE
Added flag for backward motion and renamed some params

### DIFF
--- a/graceful_controller/include/graceful_controller/graceful_controller.hpp
+++ b/graceful_controller/include/graceful_controller/graceful_controller.hpp
@@ -33,17 +33,17 @@ public:
    * @brief Constructor of the controller.
    * @param k1 Ratio of rate of change of theta to rate of change of R.
    * @param k2 How quickly we converge to the slow manifold.
-   * @param min_velocity The minimum velocity in the linear direction.
-   * @param max_velocity The maximum velocity in the linear direction.
+   * @param min_abs_velocity The minimum absolute velocity in the linear direction.
+   * @param max_abs_velocity The maximum absolute velocity in the linear direction.
    * @param max_decel The maximum deceleration in the linear direction.
-   * @param max_angular_velocity The maximum velocity in the linear direction.
+   * @param max_abs_angular_velocity The maximum absolute velocity in the angular direction.
    */
   GracefulController(double k1,
                      double k2,
-                     double min_velocity,
-                     double max_velocity,
+                     double min_abs_velocity,
+                     double max_abs_velocity,
                      double max_decel,
-                     double max_angular_velocity,
+                     double max_abs_angular_velocity,
                      double beta,
                      double lambda);
 
@@ -56,6 +56,7 @@ public:
    * @param theta The angular orientation of the goal, relative to robot base link.
    * @param vel_x The computed command velocity in the linear direction.
    * @param vel_th The computed command velocity in the angular direction.
+   * @param backward_motion Flag to indicate that the robot should move backward. False by default.
    * @returns true if there is a solution.
    */
   bool approach(const double x, const double y, const double theta,
@@ -63,13 +64,13 @@ public:
 
   /**
    * @brief Update the velocity limits.
-   * @param min_velocity The minimum velocity in the linear direction.
-   * @param max_velocity The maximum velocity in the linear direction.
-   * @param max_angular_velocity The maximum velocity in the linear direction.
+   * @param min_abs_velocity The minimum absolute velocity in the linear direction.
+   * @param max_abs_velocity The maximum absolute velocity in the linear direction.
+   * @param max_abs_angular_velocity The maximum absolute velocity in the angular direction.
    */
-  void setVelocityLimits(const double min_velocity,
-                         const double max_velocity,
-                         const double max_angular_velocity);
+  void setVelocityLimits(const double min_abs_velocity,
+                         const double max_abs_velocity,
+                         const double max_abs_angular_velocity);
 
 private:
   /*
@@ -77,12 +78,12 @@ private:
    */
   double k1_;  // ratio in change of theta to rate of change in r
   double k2_;  // speed at which we converge to slow system
-  double min_velocity_;
-  double max_velocity_;
+  double min_abs_velocity_;
+  double max_abs_velocity_;
   double max_decel_;
-  double max_angular_velocity_;
+  double max_abs_angular_velocity_;
   double beta_;  // how fast velocity drops as k increases
-  double lambda_;  // ??
+  double lambda_; // controls speed scaling based on curvature. A higher value of lambda results in more sharply peaked curves
   double dist_;  // used to create the tracking line
 };
 

--- a/graceful_controller/include/graceful_controller/graceful_controller.hpp
+++ b/graceful_controller/include/graceful_controller/graceful_controller.hpp
@@ -60,7 +60,7 @@ public:
    * @returns true if there is a solution.
    */
   bool approach(const double x, const double y, const double theta,
-                double& vel_x, double& vel_th);
+                double& vel_x, double& vel_th, bool backward_motion=false);
 
   /**
    * @brief Update the velocity limits.

--- a/graceful_controller/src/graceful_controller.cpp
+++ b/graceful_controller/src/graceful_controller.cpp
@@ -30,30 +30,30 @@ namespace graceful_controller
 {
 
 GracefulController::GracefulController(double k1, double k2,
-                                       double min_velocity, double max_velocity,
+                                       double min_abs_velocity, double max_abs_velocity,
                                        double max_decel,
-                                       double max_angular_velocity,
+                                       double max_abs_angular_velocity,
                                        double beta, double lambda)
 {
   k1_ = k1;
   k2_ = k2;
-  min_velocity_ = min_velocity;
-  max_velocity_ = max_velocity;
+  min_abs_velocity_ = min_abs_velocity;
+  max_abs_velocity_ = max_abs_velocity;
   max_decel_ = max_decel;
-  max_angular_velocity_ = max_angular_velocity;
+  max_abs_angular_velocity_ = max_abs_angular_velocity;
   beta_ = beta;
   lambda_ = lambda;
 }
 
 // x, y, theta are relative to base location and orientation
 bool GracefulController::approach(const double x, const double y, const double theta,
-                                  double& vel_x, double& vel_th)
+                                  double& vel_x, double& vel_th, bool backward_motion)
 {
   // Distance to goal
   double r = std::sqrt(x * x + y * y);
 
   // Orientation base frame relative to r_
-  double delta = std::atan2(-y, x);
+  double delta = (backward_motion) ? std::atan2(-y, -x) : std::atan2(-y, x);
 
   // Determine orientation of goal frame relative to r_
   double theta2 = angles::normalize_angle(theta + delta);
@@ -64,16 +64,16 @@ bool GracefulController::approach(const double x, const double y, const double t
   double k = -1.0/r * (k2_ * (delta - a) + (1 + (k1_/(1+((k1_*theta2)*(k1_*theta2)))))*sin(delta));
 
   // Compute max_velocity based on curvature
-  double v = max_velocity_ / (1 + beta_ * std::pow(fabs(k), lambda_));
+  double v = max_abs_velocity_ / (1 + beta_ * std::pow(fabs(k), lambda_));
   // Limit velocity based on approaching target
   double approach_limit = std::sqrt(2 * max_decel_ * r);
   v = std::min(v, approach_limit);
-  v = std::min(std::max(v, min_velocity_), max_velocity_);
+  v = std::min(std::max(v, min_abs_velocity_), max_velocity_);
 
   // Compute angular velocity
   double w = k * v;
   // Bound angular velocity
-  double bounded_w = std::min(max_angular_velocity_, std::max(-max_angular_velocity_, w));
+  double bounded_w = std::min(max_abs_angular_velocity_, std::max(-max_abs_angular_velocity_, w));
   // Make sure that if we reduce w, we reduce v so that kurvature is still followed
   if (w != 0.0)
   {
@@ -87,13 +87,13 @@ bool GracefulController::approach(const double x, const double y, const double t
 }
 
 void GracefulController::setVelocityLimits(
-  const double min_velocity,
-  const double max_velocity,
-  const double max_angular_velocity)
+  const double min_abs_velocity,
+  const double max_abs_velocity,
+  const double max_abs_angular_velocity)
 {
-  min_velocity_ = min_velocity;
-  max_velocity_ = max_velocity;
-  max_angular_velocity_ = max_angular_velocity;
+  min_abs_velocity_ = min_abs_velocity;
+  max_abs_velocity_ = max_abs_velocity;
+  max_abs_angular_velocity_ = max_abs_angular_velocity;
 }
 
 }  // namespace graceful_controller

--- a/graceful_controller/src/graceful_controller.cpp
+++ b/graceful_controller/src/graceful_controller.cpp
@@ -68,7 +68,11 @@ bool GracefulController::approach(const double x, const double y, const double t
   // Limit velocity based on approaching target
   double approach_limit = std::sqrt(2 * max_decel_ * r);
   v = std::min(v, approach_limit);
-  v = std::min(std::max(v, min_abs_velocity_), max_velocity_);
+  v = std::min(std::max(v, min_abs_velocity_), max_abs_velocity_);
+  if (backward_motion)
+  {
+    v *= -1; // reverse linear velocity direction for backward motion
+  }
 
   // Compute angular velocity
   double w = k * v;


### PR DESCRIPTION
Added optional flag to the approach method which enables backward motion:
- flip sign of x (since it's behind the robot hence the 2 quadrants are wrong)
- reverse the direction of v
Renamed velocity params to be absolute velocity params ... since that is what they really behave as.
