### PR TITLE
limit max vel theta relative to max vel x

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ one or more parameters:
    so even if a pose exceeds the filter tolerance it will not be removed
    if the gap between the pose before and after it would exceed this value.
    units: meters.
+ * **max_x_to_max_theta_scale_factor** - This limits the actual maximum angular
+   velocity relative to the current maximum x velocity (which is possibly
+   changing according to the max_vel_x ROS topic). At any moment in time, the
+   maximum angular velocity is the minimum of the absolute max (max_vel_theta,
+   see below) and this parameter multiplied by the current maximum x velocity.
+   This allows enforcing slower rotation in circumstances with lower linear
+   velocity limits. This parameter's default value is high, so whne not
+   configured, angular velocity will be limited only by max_vel_theta.
+   Units: rad/m, technically.
 
 Most of the above parameters can be left to their defaults and work well
 on a majority of robots. The following parameters, however, really do
@@ -130,8 +139,8 @@ possible:
    drivetrain and casters and cannot accurately move forward at speeds below
    some threshold, especially if also trying to turn slightly at the same time.
    Units: meters/sec.
- * **max_vel_theta** - the maximum rotation velocity that will be produced by
-   the control law. Units: rad/sec.
+ * **max_vel_theta** - the absolute maximum rotation velocity that will be
+   produced by the control law. Units: rad/sec.
  * **min_in_place_vel_theta** - this is the minimum rotation velocity that
    will be used for in-place rotations. As with _min_vel_x_, this is largely
    hardware dependent since the robot has some minimum rotational velocity

--- a/graceful_controller_ros/cfg/GracefulController.cfg
+++ b/graceful_controller_ros/cfg/GracefulController.cfg
@@ -10,6 +10,7 @@ gen.add("min_vel_x", double_t, 0, "The minimum x velocity for the robot in m/s",
 
 gen.add("max_vel_theta", double_t, 0, "The absolute value of the maximum rotational velocity for the robot in rad/s",  1.0, 0)
 gen.add("min_in_place_vel_theta", double_t, 0, "The absolute value of the minimum in-place rotational velocity the controller will explore", 0.4, 0, 20.0)
+gen.add("max_x_to_max_theta_scale_factor", double_t, 0, "Limits actual maximum rotational velocity to this factor multiplied by the local maximum linear velocity (rad/m)", 100.0, 0.1, 100.0)
 
 gen.add("acc_lim_x", double_t, 0, "The acceleration limit of the robot in the x direction", 2.5, 0, 20.0)
 gen.add("acc_lim_theta", double_t, 0, "The acceleration limit of the robot in the theta direction", 3.2, 0, 20.0)

--- a/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
+++ b/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
@@ -144,6 +144,8 @@ private:
   double max_vel_x_;
   double min_vel_x_;
   double max_vel_theta_;
+  double config_max_vel_theta_;
+  double max_x_to_max_theta_scale_factor;
   double min_in_place_vel_theta_;
   double acc_lim_x_;
   double acc_lim_theta_;

--- a/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
+++ b/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
@@ -144,8 +144,8 @@ private:
   double max_vel_x_;
   double min_vel_x_;
   double max_vel_theta_;
-  double config_max_vel_theta_;
-  double max_x_to_max_theta_scale_factor;
+  double max_vel_theta_limited_;
+  double max_x_to_max_theta_scale_factor_;
   double min_in_place_vel_theta_;
   double acc_lim_x_;
   double acc_lim_theta_;

--- a/graceful_controller_ros/src/graceful_controller_ros.cpp
+++ b/graceful_controller_ros/src/graceful_controller_ros.cpp
@@ -756,6 +756,9 @@ void GracefulControllerROS::velocityCallback(const std_msgs::Float32::ConstPtr& 
   std::lock_guard<std::mutex> lock(config_mutex_);
 
   max_vel_x_ = std::max(static_cast<double>(max_vel_x->data), min_vel_x_);
+  // also limit maximum angular velocity proportional to maximum linear velocity
+  // so we don't make fast in-place turns in areas with low speed limits
+  max_vel_theta_ = std::min(2 * max_vel_x, max_vel_theta_);
 }
 
 void computeDistanceAlongPath(const std::vector<geometry_msgs::PoseStamped>& poses,

--- a/graceful_controller_ros/src/graceful_controller_ros.cpp
+++ b/graceful_controller_ros/src/graceful_controller_ros.cpp
@@ -243,7 +243,7 @@ void GracefulControllerROS::reconfigureCallback(GracefulControllerConfig& config
   min_vel_x_ = config.min_vel_x;
   max_vel_theta_ = config.max_vel_theta;
   min_in_place_vel_theta_ = config.min_in_place_vel_theta;
-  max_x_to_max_theta_scale_factor = config.max_x_to_max_theta_scale_factor;
+  max_x_to_max_theta_scale_factor_ = config.max_x_to_max_theta_scale_factor;
   acc_lim_x_ = config.acc_lim_x;
   acc_lim_theta_ = config.acc_lim_theta;
   decel_lim_x_ = config.decel_lim_x;
@@ -276,7 +276,8 @@ void GracefulControllerROS::reconfigureCallback(GracefulControllerConfig& config
 
   // limit maximum angular velocity proportional to maximum linear velocity
   // so we don't make fast in-place turns in areas with low speed limits
-  max_vel_theta_limited_ = std::min(max_vel_x * max_x_to_max_theta_scale_factor, max_vel_theta_);
+  max_vel_theta_limited_ = max_vel_x_ * max_x_to_max_theta_scale_factor_;
+  max_vel_theta_limited_ = std::min(max_vel_theta_limited_, max_vel_theta_);
 
   controller_ =
       std::make_shared<GracefulController>(config.k1, config.k2, config.min_vel_x, config.max_vel_x, decel_lim_x_,
@@ -769,7 +770,8 @@ void GracefulControllerROS::velocityCallback(const std_msgs::Float32::ConstPtr& 
   max_vel_x_ = std::max(static_cast<double>(max_vel_x->data), min_vel_x_);
   // also limit maximum angular velocity proportional to maximum linear velocity
   // so we don't make fast in-place turns in areas with low speed limits
-  max_vel_theta_limited_ = std::min(max_vel_x * max_x_to_max_theta_scale_factor, max_vel_theta_);
+  max_vel_theta_limited_ = max_vel_x_ * max_x_to_max_theta_scale_factor_;
+  max_vel_theta_limited_ = std::min(max_vel_theta_limited_, max_vel_theta_);
 }
 
 void computeDistanceAlongPath(const std::vector<geometry_msgs::PoseStamped>& poses,


### PR DESCRIPTION
Make it so in highly speed limited areas, we throttle our maximum theta vel.
Add a parameter max_x_to_max_theta_scale_factor that limits maximum angular velocity to max_x_to_max_theta_scale_factor * max_vel_x_