### PR TITLE
add angular velocity limiting control

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ one or more parameters:
    so even if a pose exceeds the filter tolerance it will not be removed
    if the gap between the pose before and after it would exceed this value.
    units: meters.
+ * **max_x_to_max_theta_scale_factor** - This limits the actual maximum angular
+   velocity relative to the current maximum x velocity (which is possibly
+   changing according to the max_vel_x ROS topic). At any moment in time, the
+   maximum angular velocity is the minimum of the absolute max (max_vel_theta,
+   see below) and this parameter multiplied by the current maximum x velocity.
+   This allows enforcing slower rotation in circumstances with lower linear
+   velocity limits. This parameter's default value is high, so whne not
+   configured, angular velocity will be limited only by max_vel_theta.
+   Units: rad/m, technically.
 
 Most of the above parameters can be left to their defaults and work well
 on a majority of robots. The following parameters, however, really do
@@ -122,8 +131,8 @@ possible:
    drivetrain and casters and cannot accurately move forward at speeds below
    some threshold, especially if also trying to turn slightly at the same time.
    Units: meters/sec.
- * **max_vel_theta** - the maximum rotation velocity that will be produced by
-   the control law. Units: rad/sec.
+ * **max_vel_theta** - the absolute maximum rotation velocity that will be
+   produced by the control law. Units: rad/sec.
  * **min_in_place_vel_theta** - this is the minimum rotation velocity that
    will be used for in-place rotations. As with _min_vel_x_, this is largely
    hardware dependent since the robot has some minimum rotational velocity

--- a/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
+++ b/graceful_controller_ros/include/graceful_controller_ros/graceful_controller_ros.hpp
@@ -172,6 +172,8 @@ private:
   double max_vel_x_;
   double min_vel_x_;
   double max_vel_theta_;
+  double max_vel_theta_limited_;
+  double max_x_to_max_theta_scale_factor_;
   double min_in_place_vel_theta_;
   double acc_lim_x_;
   double acc_lim_theta_;

--- a/graceful_controller_ros/src/graceful_controller_ros.cpp
+++ b/graceful_controller_ros/src/graceful_controller_ros.cpp
@@ -239,6 +239,12 @@ void GracefulControllerROS::configure(
   node->get_parameter(name_ + ".beta", beta);
   node->get_parameter(name_ + ".lambda", lambda);
 
+  if (max_x_to_max_theta_scale_factor_ < 0.001)
+  {
+    // If max_x_to_max_theta_scale_factor not specified, use a high value so it has no functional impact
+    max_x_to_max_theta_scale_factor_ = 100.0;
+  }
+
   // Limit maximum angular velocity proportional to maximum linear velocity
   max_vel_theta_limited_ = max_vel_x_ * max_x_to_max_theta_scale_factor_;
   max_vel_theta_limited_ = std::min(max_vel_theta_limited_, max_vel_theta_);
@@ -270,7 +276,7 @@ void GracefulControllerROS::configure(
                                                      min_vel_x_,
                                                      max_vel_x_,
                                                      decel_lim_x_,
-                                                     max_vel_theta_limited_,
+                                                     max_vel_theta_,
                                                      beta,
                                                      lambda);
 


### PR DESCRIPTION
Adds max_x_to_max_theta_scale_factor which can be used to
control how the angular velocity changes relative to the linear
velocity when use_vel_topic feature is enabled.

This is a port of #61 to ROS2