### PR TITLE
fix stutter when robot velocity exceeds max_vel_x

### DIFF
--- a/graceful_controller_ros/src/graceful_controller_ros.cpp
+++ b/graceful_controller_ros/src/graceful_controller_ros.cpp
@@ -424,7 +424,8 @@ geometry_msgs::msg::TwistStamped GracefulControllerROS::computeVelocityCommands(
   {
     // If our velocity limit has recently changed,
     // decelerate towards desired max_vel_x while still respecting acceleration limits
-    max_vel_x = velocity.linear.x - (decel_lim_x_ * acc_dt_);
+    double decelerating_max_vel_x = velocity.linear.x - (decel_lim_x_ * acc_dt_);
+    max_vel_x = std::max(max_vel_x, decelerating_max_vel_x);
     max_vel_x = std::max(max_vel_x, min_vel_x_);
   }
   else


### PR DESCRIPTION
a bit of noise on the odometry can cause the robot to overshoot the max_vel_x - this would then cause us to decelerate - possibly quite hard if the decel_lim_x was high.

This is a port of #69 to ROS2